### PR TITLE
Fix: uci knight promotion

### DIFF
--- a/uci/src/main.rs
+++ b/uci/src/main.rs
@@ -128,7 +128,7 @@ fn parse_message(msg: &str) -> UciMessage {
                         if let Some(p) = chars.next() {
                             Some(match p {
                                 'q' => UciPiece::Queen,
-                                'k' => UciPiece::Knight,
+                                'n' => UciPiece::Knight,
                                 'r' => UciPiece::Rook,
                                 'b' => UciPiece::Bishop,
                                 _ => return None


### PR DESCRIPTION
Change 'k' to 'n' for knight promotion check in uci.